### PR TITLE
Scipy version fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 History
 =======
 
+0.1.9 (2017-03-16)
+------------------
+
+* Fix minimum scipy version required.
+
+
+0.1.8 (2017-03-16)
+------------------
+
+* Fix missing Pillow dependency.
+
+
 0.1.7 (2017-03-13)
 ------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Click>=6.0
 dlib>=19.3.0
 numpy
 Pillow
-scipy
+scipy>=0.17.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'dlib>=19.3.0',
     'numpy',
     'Pillow',
-    'scipy'
+    'scipy>=0.17.0'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ test_requirements = [
 
 setup(
     name='face_recognition',
-    version='0.1.8',
+    version='0.1.9',
     description="Recognize faces from Python or from the command line",
     long_description=readme + '\n\n' + history,
     author="Adam Geitgey",


### PR DESCRIPTION
`scipy >= 0.17.0` is required or image loading will fail due to `scipy` not supporting the `mode` parameter.