### PR TITLE
Replace _face_distance with more efficient calculation

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -61,7 +61,7 @@ def _face_distance(faces, face_to_compare):
     :param face_to_compare: A face encoding to compare against
     :return: A list with the distance for each face in the same order as the 'faces' array
     """
-    return np.array([np.linalg.norm(face - face_to_compare) for face in faces])
+    return np.linalg.norm(faces - face_to_compare, axis=1)
 
 
 def load_image_file(filename, mode='RGB'):


### PR DESCRIPTION
From http://stackoverflow.com/questions/7741878/how-to-apply-numpy-linalg-norm-to-each-row-of-a-matrix

Running time comparisons (prev vs. new, performed using faces = np.random.rand(n, 128), face_to_compare = np.random.rand(1, 128))
n = 1M:  5.3s vs. 1.1s
n = 5M:  26.9s vs. 6.6s
n = 10M: 52.6s vs. 23s