### PR TITLE
Ignore known files with no faces in CLI

### DIFF
--- a/face_recognition/cli.py
+++ b/face_recognition/cli.py
@@ -22,9 +22,9 @@ def scan_known_people(known_people_folder):
 
         if len(encodings) == 0:
             click.echo("WARNING: No faces found in {}. Ignoring file.".format(file))
-
-        known_names.append(basename)
-        known_face_encodings.append(encodings[0])
+        else:
+            known_names.append(basename)
+            known_face_encodings.append(encodings[0])
 
     return known_names, known_face_encodings
 


### PR DESCRIPTION
In the CLI, if a known_image contains no faces it currently cases because this `else` statement was missing.

Fixes #34 