### PR TITLE
Convert 1600 to a float.

### DIFF
--- a/face_recognition/cli.py
+++ b/face_recognition/cli.py
@@ -34,7 +34,7 @@ def test_image(image_to_check, known_names, known_face_encodings):
 
     # Scale down image if it's giant so things run a little faster
     if unknown_image.shape[1] > 1600:
-        scale_factor = 1600 / unknown_image.shape[1]
+        scale_factor = 1600.0 / unknown_image.shape[1]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             unknown_image = scipy.misc.imresize(unknown_image, scale_factor)


### PR DESCRIPTION
If `unknown_image.shape[1] > 1600` then `scale_factor` will be always calculated `0` because `1600 / unknown_image.shape[1]` is an `int` over `int` division which in turn will always raise a ValueError in `PIL.Image.resize`. Making `1600` a float (1600.0) fixes the issue.