### PR TITLE
Clarify that file object is also a valid parameter to load_image_file

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -67,15 +67,15 @@ def face_distance(face_encodings, face_to_compare):
     return np.linalg.norm(face_encodings - face_to_compare, axis=1)
 
 
-def load_image_file(name, mode='RGB'):
+def load_image_file(file, mode='RGB'):
     """
     Loads an image file (.jpg, .png, etc) into a numpy array
 
-    :param name: image file name or file object to load
+    :param file: image file name or file object to load
     :param mode: format to convert the image to. Only 'RGB' (8-bit RGB, 3 channels) and 'L' (black and white) are supported.
     :return: image contents as numpy array
     """
-    return scipy.misc.imread(name, mode=mode)
+    return scipy.misc.imread(file, mode=mode)
 
 
 def _raw_face_locations(img, number_of_times_to_upsample=1):

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -67,15 +67,15 @@ def face_distance(face_encodings, face_to_compare):
     return np.linalg.norm(face_encodings - face_to_compare, axis=1)
 
 
-def load_image_file(filename, mode='RGB'):
+def load_image_file(name, mode='RGB'):
     """
     Loads an image file (.jpg, .png, etc) into a numpy array
 
-    :param filename: image file to load
+    :param name: image file name or file object to load
     :param mode: format to convert the image to. Only 'RGB' (8-bit RGB, 3 channels) and 'L' (black and white) are supported.
     :return: image contents as numpy array
     """
-    return scipy.misc.imread(filename, mode=mode)
+    return scipy.misc.imread(name, mode=mode)
 
 
 def _raw_face_locations(img, number_of_times_to_upsample=1):


### PR DESCRIPTION
Because face_recognition.load_image_file simply wraps scipy.misc.imread, it is also possible for load_image_file to take a file object, not just a filename.

Clarify this in the api by renaming filename to name and adjusting the docstring, in accordance to scipy.misc.imread.

I am not 100% sure about the renaming of the parameter though since it is an API breakage, if a mild one. Maybe just adjusting the docstring and skipping the rename of the parameter is the better option here.