### PR TITLE
Support for new dlib 19.7 stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --fix-missing \
 
 RUN cd ~ && \
     mkdir -p dlib && \
-    git clone -b 'v19.5' --single-branch https://github.com/davisking/dlib.git dlib/ && \
+    git clone -b 'v19.7' --single-branch https://github.com/davisking/dlib.git dlib/ && \
     cd  dlib/ && \
     python3 setup.py install --yes USE_AVX_INSTRUCTIONS
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+1.1.0 (2017-09-23)
+------------------
+
+* Will use dlib's 5-point face pose estimator when possible for speed (instead of 68-point face pose esimator)
+* dlib v19.7 is now the minimum required version
+* face_recognition_models v0.3.0 is now the minimum required version
+
+
 1.0.0 (2017-08-29)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See [this example](https://github.com/ageitgey/face_recognition/blob/master/exam
 
 ### Installation Options:
 
-#### Installing on Mac or Linux 
+#### Installing on Mac or Linux
 
 First, make sure you have dlib already installed with Python bindings:
 
@@ -105,8 +105,8 @@ While Windows isn't officially supported, helpful users have posted instuctions 
 
 #### Installing a pre-configured Virtual Machine image
 
-  * [Download the pre-configured VM image](https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b) (for VMware Player or VirtualBox). 
-  
+  * [Download the pre-configured VM image](https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b) (for VMware Player or VirtualBox).
+
 ## Usage
 
 #### Command-Line Interface
@@ -341,11 +341,11 @@ try `pip2 --no-cache-dir install face_recognition` to avoid the issue.
 
 Issue: `AttributeError: 'module' object has no attribute 'face_recognition_model_v1'`
 
-Solution: The version of `dlib` you have installed is too old. You need version 19.5 or newer. Upgrade `dlib`.
+Solution: The version of `dlib` you have installed is too old. You need version 19.7 or newer. Upgrade `dlib`.
 
 Issue: `Attribute Error: 'Module' object has no attribute 'cnn_face_detection_model_v1'`
 
-Solution: The version of `dlib` you have installed is too old. You need version 19.5 or newer. Upgrade `dlib`.
+Solution: The version of `dlib` you have installed is too old. You need version 19.7 or newer. Upgrade `dlib`.
 
 Issue: `TypeError: imread() got an unexpected keyword argument 'mode'`
 

--- a/README.rst
+++ b/README.rst
@@ -87,39 +87,55 @@ for the code.
 Installation
 ------------
 
-Requirements:
+Requirements
+~~~~~~~~~~~~
 
--  Python 3+ or Python 2.7
--  macOS or Linux (Windows untested)
--  `Also can run on a Raspberry Pi 2+ (follow these specific
-   instructions) <https://gist.github.com/ageitgey/1ac8dbe8572f3f533df6269dab35df65>`__
--  A `pre-configured VM
-   image <https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b>`__
-   is also available.
+-  Python 3.3+ or Python 2.7
+-  macOS or Linux (Windows not officially supported, but might work)
 
-Install this module from pypi using ``pip3`` (or ``pip2`` for Python 2):
+Installation Options:
+~~~~~~~~~~~~~~~~~~~~~
+
+Installing on Mac or Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+First, make sure you have dlib already installed with Python bindings:
+
+-  `How to install dlib from source on macOS or
+   Ubuntu <https://gist.github.com/ageitgey/629d75c1baac34dfa5ca2a1928a7aeaf>`__
+
+Then, install this module from pypi using ``pip3`` (or ``pip2`` for
+Python 2):
 
 .. code:: bash
 
     pip3 install face_recognition
 
-| IMPORTANT NOTE: It's very likely that you will run into problems when
-  pip tries to compile
-| the ``dlib`` dependency. If that happens, check out this guide to
-  installing
-| dlib from source (instead of from pip) to fix the error:
-
-`How to install dlib from
-source <https://gist.github.com/ageitgey/629d75c1baac34dfa5ca2a1928a7aeaf>`__
-
-| After manually installing ``dlib``, try running
-  ``pip3 install face_recognition``
-| again to complete your installation.
-
-| If you are still having trouble installing this, you can also try out
-  this
+| If you are having trouble with installation, you can also try out a
 | `pre-configured
   VM <https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b>`__.
+
+Installing on Raspberry Pi 2+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  `Raspberry Pi 2+ installation
+   instructions <https://gist.github.com/ageitgey/1ac8dbe8572f3f533df6269dab35df65>`__
+
+Installing on Windows
+^^^^^^^^^^^^^^^^^^^^^
+
+While Windows isn't officially supported, helpful users have posted
+instuctions on how to install this library:
+
+-  `@masoudr's Windows 10 installation guide (dlib +
+   face\_recognition) <https://github.com/ageitgey/face_recognition/issues/175#issue-257710508>`__
+
+Installing a pre-configured Virtual Machine image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+-  `Download the pre-configured VM
+   image <https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b>`__
+   (for VMware Player or VirtualBox).
 
 Usage
 -----
@@ -223,7 +239,7 @@ If you are using Python 3.4 or newer, pass in a
 
 .. code:: bash
 
-    $ face_recognition -cpus 4 ./pictures_of_people_i_know/ ./unknown_pictures/
+    $ face_recognition --cpus 4 ./pictures_of_people_i_know/ ./unknown_pictures/
 
 You can also pass in ``--cpus -1`` to use all CPU cores in your system.
 
@@ -427,7 +443,13 @@ Issue:
 ``AttributeError: 'module' object has no attribute 'face_recognition_model_v1'``
 
 Solution: The version of ``dlib`` you have installed is too old. You
-need version 19.4 or newer. Upgrade ``dlib``.
+need version 19.7 or newer. Upgrade ``dlib``.
+
+Issue:
+``Attribute Error: 'Module' object has no attribute 'cnn_face_detection_model_v1'``
+
+Solution: The version of ``dlib`` you have installed is too old. You
+need version 19.7 or newer. Upgrade ``dlib``.
 
 Issue: ``TypeError: imread() got an unexpected keyword argument 'mode'``
 

--- a/examples/recognize_faces_in_pictures.py
+++ b/examples/recognize_faces_in_pictures.py
@@ -6,7 +6,7 @@ obama_image = face_recognition.load_image_file("obama.jpg")
 unknown_image = face_recognition.load_image_file("obama2.jpg")
 
 # Get the face encodings for each face in each image file
-# Since there could be more than one face in each image, it returns a list of encordings.
+# Since there could be more than one face in each image, it returns a list of encodings.
 # But since I know each image only has one face, I only care about the first encoding in each image, so I grab index 0.
 biden_face_encoding = face_recognition.face_encodings(biden_image)[0]
 obama_face_encoding = face_recognition.face_encodings(obama_image)[0]

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'face_recognition_models>=0.2.0',
+    'face_recognition_models>=0.3.0',
     'Click>=6.0',
-    'dlib>=19.5',
+    'dlib>=19.7',
     'numpy',
     'Pillow',
     'scipy>=0.17.0'
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='face_recognition',
-    version='1.0.0',
+    version='1.1.0',
     description="Recognize faces from Python or from the command line",
     long_description=readme + '\n\n' + history,
     author="Adam Geitgey",


### PR DESCRIPTION
- Bump version to 1.1.0
- Require dlib 19.7 and face_recognition_models 0.3.0
- Support the new slimmer 5-point face post model when creating face encodings. This speed things up slightly (a few fps in some cases)
- Update docs/Dockerfile everywhere to say dlib 19.7 instead of dlib 19.5

See http://blog.dlib.net/2017/09/fast-multiclass-object-detection-in.html for context on dlib speed-ups

Now that redundant face pose models are being loaded, it makes sense to start lazy loading them to save ram (especially on an RPi). But I didn't do that yet because I haven't tested how it might interact with python's different multiprocessing modes when using more than one thread.