### PR TITLE
Corrected the spelling in api.py file.

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -141,7 +141,7 @@ def face_encodings(face_image, known_face_locations=None, num_jitters=1):
     :param face_image: The image that contains one or more faces
     :param known_face_locations: Optional - the bounding boxes of each face if you already know them.
     :param num_jitters: How many times to re-sample the face when calculating encoding. Higher is more accurate, but slower (i.e. 100 is 100x slower)
-    :return: A list of 128-dimentional face encodings (one for each face in the image)
+    :return: A list of 128-dimensional face encodings (one for each face in the image)
     """
     raw_landmarks = _raw_face_landmarks(face_image, known_face_locations)
 


### PR DESCRIPTION
Changed the spelling of "dimentional" to "dimensional" in comments section of api.py file .