### PR TITLE
Add support for Windows if using Python 3.6 via Anaconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ While Windows isn't officially supported, helpful users have posted instuctions 
 
   * [@masoudr's Windows 10 installation guide (dlib + face_recognition)](https://github.com/ageitgey/face_recognition/issues/175#issue-257710508)
 
+Here's an easier way to install on Windows using Anaconda and Python 3.6 if you don't mind not having access to Dlib's CNN Face Detection Model:
+
+- Download the Python 3.6 version of [Anaconda](https://www.anaconda.com/download/)
+- (Optional) If you encounter errors, you may need to install in a new environment:
+  - `conda create -n newenv python=3.6`
+  - `activate newenv`
+  - replace newenv with the name of your environment
+- Then run the script `setup_windows.bat` from a command line (not powershell)
+
 #### Installing a pre-configured Virtual Machine image
 
   * [Download the pre-configured VM image](https://medium.com/@ageitgey/try-deep-learning-in-python-now-with-a-fully-pre-configured-vm-1d97d4c3e9b) (for VMware Player or VirtualBox).

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -3,6 +3,7 @@
 import scipy.misc
 import dlib
 import numpy as np
+import warnings
 
 try:
     import face_recognition_models
@@ -21,7 +22,16 @@ predictor_5_point_model = face_recognition_models.pose_predictor_five_point_mode
 pose_predictor_5_point = dlib.shape_predictor(predictor_5_point_model)
 
 cnn_face_detection_model = face_recognition_models.cnn_face_detector_model_location()
-cnn_face_detector = dlib.cnn_face_detection_model_v1(cnn_face_detection_model)
+
+class NoDlibCNNFaceDetection(Exception):
+    pass
+
+try:
+    cnn_face_detector = dlib.cnn_face_detection_model_v1(cnn_face_detection_model)
+except AttributeError:
+    warnings.warn("Warning: your dlib doesn't support cnn_face_detection_model_v1", ImportWarning)
+    def cnn_face_detector(*args, **kwargs):
+        raise(NoDlibCNNFaceDetection)
 
 face_recognition_model = face_recognition_models.face_recognition_model_location()
 face_encoder = dlib.face_recognition_model_v1(face_recognition_model)

--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -1,0 +1,5 @@
+face_recognition_models
+Click>=6.0
+numpy
+Pillow
+scipy>=0.17.0

--- a/setup_windows.bat
+++ b/setup_windows.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Make sure you've installed Anaconda: https://www.anaconda.com/download/
+echo Make sure you've installed the Python 3.6 version of Anaconda: https://www.anaconda.com/download/
 conda install -c conda-forge dlib numpy Pillow
 conda install scipy Click
 pip install -r requirements_windows.txt

--- a/setup_windows.bat
+++ b/setup_windows.bat
@@ -1,0 +1,6 @@
+@echo off
+echo Make sure you've installed Anaconda: https://www.anaconda.com/download/
+conda install -c conda-forge dlib numpy Pillow
+conda install scipy Click
+pip install -r requirements_windows.txt
+pip install -U --no-deps .


### PR DESCRIPTION
I've been able to install this using Python 3.6 in Anaconda on a Windows 10 machine.  I've verified it works on an empty environment.  However, it the CNN Face Detection model doesn't work currently since they're not supported by the version of Dlib in Anaconda's Conda-Forge repository.

Let me know if this is an acceptable workaround for Windows users and if so, feel free to merge this pull request.