### PR TITLE
Remove scipy dependency and bump version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['face_recognition_models', 'Click', 'dlib', 'numpy', 'scipy', 'scipy.misc']
+MOCK_MODULES = ['face_recognition_models', 'Click', 'dlib', 'numpy', 'PIL']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another

--- a/face_recognition/__init__.py
+++ b/face_recognition/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Adam Geitgey"""
 __email__ = 'ageitgey@gmail.com'
-__version__ = '0.1.0'
+__version__ = '1.2.2'
 
 from .api import load_image_file, face_locations, batch_face_locations, face_landmarks, face_encodings, compare_faces, face_distance

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import scipy.misc
+import PIL.Image
 import dlib
 import numpy as np
 
@@ -81,7 +81,10 @@ def load_image_file(file, mode='RGB'):
     :param mode: format to convert the image to. Only 'RGB' (8-bit RGB, 3 channels) and 'L' (black and white) are supported.
     :return: image contents as numpy array
     """
-    return scipy.misc.imread(file, mode=mode)
+    im = PIL.Image.open(file)
+    if mode:
+        im = im.convert(mode)
+    return np.array(im)
 
 
 def _raw_face_locations(img, number_of_times_to_upsample=1, model="hog"):
@@ -195,7 +198,6 @@ def face_encodings(face_image, known_face_locations=None, num_jitters=1):
     :return: A list of 128-dimensional face encodings (one for each face in the image)
     """
     raw_landmarks = _raw_face_landmarks(face_image, known_face_locations, model="small")
-
     return [np.array(face_encoder.compute_face_descriptor(face_image, raw_landmark_set, num_jitters)) for raw_landmark_set in raw_landmarks]
 
 

--- a/face_recognition/cli.py
+++ b/face_recognition/cli.py
@@ -3,12 +3,12 @@ from __future__ import print_function
 import click
 import os
 import re
-import scipy.misc
-import warnings
 import face_recognition.api as face_recognition
 import multiprocessing
 import itertools
 import sys
+import PIL.Image
+import numpy as np
 
 
 def scan_known_people(known_people_folder):
@@ -43,11 +43,10 @@ def test_image(image_to_check, known_names, known_face_encodings, tolerance=0.6,
     unknown_image = face_recognition.load_image_file(image_to_check)
 
     # Scale down image if it's giant so things run a little faster
-    if unknown_image.shape[1] > 1600:
-        scale_factor = 1600.0 / unknown_image.shape[1]
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            unknown_image = scipy.misc.imresize(unknown_image, scale_factor)
+    if max(unknown_image.shape) > 1600:
+        pil_img = PIL.Image.fromarray(unknown_image)
+        pil_img.thumbnail((1600, 1600), PIL.Image.LANCZOS)
+        unknown_image = np.array(pil_img)
 
     unknown_encodings = face_recognition.face_encodings(unknown_image)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 1.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ requirements = [
     'Click>=6.0',
     'dlib>=19.7',
     'numpy',
-    'Pillow',
-    'scipy>=0.17.0'
+    'Pillow'
 ]
 
 test_requirements = [
@@ -25,7 +24,7 @@ test_requirements = [
 
 setup(
     name='face_recognition',
-    version='1.2.1',
+    version='1.2.2',
     description="Recognize faces from Python or from the command line",
     long_description=readme + '\n\n' + history,
     author="Adam Geitgey",

--- a/tests/test_face_recognition.py
+++ b/tests/test_face_recognition.py
@@ -246,6 +246,17 @@ class Test_face_recognition(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertTrue(target_string in result.output)
 
+    def test_command_line_interface_big_image(self):
+        target_string = 'obama3.jpg,obama'
+        runner = CliRunner()
+        image_folder = os.path.join(os.path.dirname(__file__), 'test_images')
+        image_file = os.path.join(os.path.dirname(__file__), 'test_images', 'obama3.jpg')
+
+        result = runner.invoke(cli.main, args=[image_folder, image_file])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(target_string in result.output)
+
     def test_command_line_interface_tolerance(self):
         target_string = 'obama.jpg,obama'
         runner = CliRunner()


### PR DESCRIPTION
Remove scipy dependency because it's not really needed, it's hard to install on windows, and it's a common source of help requests.

See for reference: #382

Fixes: #363
Fixes: #301
Fixes: #242
Fixes: #103
Fixes: #6
Fixes: #10