### PR TITLE
Add Python 3.7 version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ install:
   - pip install tox-travis
 
 script: tox
+
+# Temporary for Python 3.7
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true


### PR DESCRIPTION
CI build (all python interpreter versions) passed, following link provided below:
https://travis-ci.org/duboviy/face_recognition

[Additional Note]:
Right now Python 3.7 version can't be simply added (without specifying 'xenial' dist & sudo) due to Travis-CI issue:
https://github.com/travis-ci/travis-ci/issues/9815
So I'd suggest to use following changes before Travis-CI issue is fixed as it's done in other big python projects with 3.7 python support.