### PR TITLE
Example fix for multi-face images.

### DIFF
--- a/examples/digital_makeup.py
+++ b/examples/digital_makeup.py
@@ -7,8 +7,8 @@ image = face_recognition.load_image_file("biden.jpg")
 # Find all facial features in all the faces in the image
 face_landmarks_list = face_recognition.face_landmarks(image)
 
+pil_image = Image.fromarray(image)
 for face_landmarks in face_landmarks_list:
-    pil_image = Image.fromarray(image)
     d = ImageDraw.Draw(pil_image, 'RGBA')
 
     # Make the eyebrows into a nightmare


### PR DESCRIPTION
This fix allows for makeup to be applied to all faces in the image. The previous version would only apply makeup to one face since the new base image would be created each time loop would start.