### PR TITLE
DLIB build removed the --yes option: Dockerfile updated

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -27,7 +27,7 @@ RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 50
 
 #Install dlib 
 
-RUN git clone https://github.com/davisking/dlib.git
+RUN git clone -b 'v19.16' --single-branch https://github.com/davisking/dlib.git
 RUN mkdir -p /dlib/build
 
 RUN cmake -H/dlib -B/dlib/build -DDLIB_USE_CUDA=1 -DUSE_AVX_INSTRUCTIONS=1

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -33,7 +33,7 @@ RUN mkdir -p /dlib/build
 RUN cmake -H/dlib -B/dlib/build -DDLIB_USE_CUDA=1 -DUSE_AVX_INSTRUCTIONS=1
 RUN cmake --build /dlib/build
 
-RUN cd /dlib; python3 /dlib/setup.py install --yes USE_AVX_INSTRUCTIONS --yes DLIB_USE_CUDA
+RUN cd /dlib; python3 /dlib/setup.py install
 
 # Install the face recognition package
 


### PR DESCRIPTION
[DLIB](https://github.com/davisking/dlib) repository removed the `--yes` option on the setup.py:
https://github.com/davisking/dlib/commit/b892df823268446012ff9717ed9544cfa891a30b

Using `--yes USE_AVX_INSTRUCTIONS --yes DLIB_USE_CUDA` generates the following error:
```
Step 13/14 : RUN cd /dlib; python3 /dlib/setup.py install --yes USE_AVX_INSTRUCTIONS --yes DLIB_USE_CUDA
 ---> Running in 7746a50797fd
The --yes options to dlib's setup.py don't do anything since all these options 
are on by default.  So --yes has been removed.  Do not give it to setup.py.
ERROR: Service 'face_recognition' failed to build: The command '/bin/sh -c cd /dlib; python3 /dlib/setup.py install --yes USE_AVX_INSTRUCTIONS --yes DLIB_USE_CUDA' returned a non-zero code: 1
```