### PR TITLE
Fixed occasional "zombie" processes from running `facerec_from_webcam_multiprocessing.py`

### DIFF
--- a/examples/facerec_from_webcam_multiprocessing.py
+++ b/examples/facerec_from_webcam_multiprocessing.py
@@ -62,6 +62,10 @@ def process(worker_id, read_frame_list, write_frame_list, Global, worker_num):
 
         # Wait to read
         while Global.read_num != worker_id or Global.read_num != prev_id(Global.buff_num, worker_num):
+            # If the user has requested to end the app, then stop waiting for webcam frames
+            if Global.is_exit:
+                break
+
             time.sleep(0.01)
 
         # Delay to make the video look smoother


### PR DESCRIPTION
This PR offers a bug fix for the multiprocessing-based webcam face recognition demo. Occasionally, when the user requests to quit the demo, the camera worker will close before the face recognizer processes, which can cause them to keep waiting for frames to process when there are none.

This bug fix fixes that issue by checking if the user has requested to quit the demo while waiting for more frames to process and exiting when that's the case.