### PR TITLE
Need to show only one predicted name per face

### DIFF
--- a/face_recognition/face_recognition_cli.py
+++ b/face_recognition/face_recognition_cli.py
@@ -52,12 +52,24 @@ def test_image(image_to_check, known_names, known_face_encodings, tolerance=0.6,
 
     for unknown_encoding in unknown_encodings:
         distances = face_recognition.face_distance(known_face_encodings, unknown_encoding)
+        
+        '''
         result = list(distances <= tolerance)
 
         if True in result:
             [print_result(image_to_check, name, distance, show_distance) for is_match, name, distance in zip(result, known_names, distances) if is_match]
         else:
             print_result(image_to_check, "unknown_person", None, show_distance)
+        '''
+        
+        distances=list(distances)
+        if(min(distances)<=tolerance):
+            final_match = distances.index(min(distances))
+            print_result(image_to_check,known_names[final_match],min(distances),show_distance)
+        else:
+            print_result(image_to_check, "unknown_person", None, show_distance)
+            
+        
 
     if not unknown_encodings:
         # print out fact that no faces were found in image

--- a/face_recognition/face_recognition_cli.py
+++ b/face_recognition/face_recognition_cli.py
@@ -38,8 +38,7 @@ def print_result(filename, name, distance, show_distance=False):
     else:
         print("{},{}".format(filename, name))
 
-
-def test_image(image_to_check, known_names, known_face_encodings, tolerance=0.6, show_distance=False):
+def test_image(image_to_check, known_names, known_face_encodings, tolerance=0.9, show_distance=False):
     unknown_image = face_recognition.load_image_file(image_to_check)
 
     # Scale down image if it's giant so things run a little faster
@@ -63,6 +62,7 @@ def test_image(image_to_check, known_names, known_face_encodings, tolerance=0.6,
         '''
         
         distances=list(distances)
+        
         if(min(distances)<=tolerance):
             final_match = distances.index(min(distances))
             print_result(image_to_check,known_names[final_match],min(distances),show_distance)


### PR DESCRIPTION
While Displaying an image a face can be represented with one name.! That should be the smallest face distance and less than tolerance. Many people take one value less than tolerance that does not be always true.
"In my case, there are seven faces but it gave nine names." But new code gives only one with less face distance and less than tolerance.
Please verify the code and accept the pull request.
