### PR TITLE
Dockerfile example libatlas-dev update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y --fix-missing \
     curl \
     graphicsmagick \
     libgraphicsmagick1-dev \
-    libatlas-dev \
+    libatlas-base-dev \
     libavcodec-dev \
     libavformat-dev \
     libgtk2.0-dev \


### PR DESCRIPTION
Old apt-get`libatlas-dev` updated to it's new `libatlas-base-dev` reference in the example Dockerfile.