### PR TITLE
Add build-system dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The configuration under `[build-system]` inside of `pyproject.toml` specifies the _build-time_ dependencies, which are setuptools and wheel for this project. They may seem obvious to have but there are some cases in which they aren't present (e.g., inside a Docker container, that they try to be minimal in size). This makes `pip install face_recognition` first install these dependencies before installing itself. See [PEP 518](https://www.python.org/dev/peps/pep-0518/).