### PR TITLE
Batch face encodings

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -211,8 +211,9 @@ def face_encodings(face_image, known_face_locations=None, num_jitters=1, model="
     :return: A list of 128-dimensional face encodings (one for each face in the image)
     """
     raw_landmarks = _raw_face_landmarks(face_image, known_face_locations, model)
-    return [np.array(face_encoder.compute_face_descriptor(face_image, raw_landmark_set, num_jitters)) for raw_landmark_set in raw_landmarks]
-
+    landmarks_as_fod = dlib.full_object_detections()
+    landmarks_as_fod.extend(raw_landmarks)
+    return np.array(face_encoder.compute_face_descriptor(face_image, landmarks_as_fod, num_jitters))
 
 def compare_faces(known_face_encodings, face_encoding_to_check, tolerance=0.6):
     """


### PR DESCRIPTION
Batch face encodings with using landmark as dlib full object detection

test with single image containing 50 face (42 face detected):
Original:
```
time taken: 0.2927389144897461 42
time taken: 0.2869551181793213 42
time taken: 0.278911828994751 42
time taken: 0.27754902839660645 42
time taken: 0.27735042572021484 42
time taken: 0.2752363681793213 42
time taken: 0.2764449119567871 42
time taken: 0.27690911293029785 42
time taken: 0.2756640911102295 42
time taken: 0.274813175201416 42
average time: 0.27925729751586914
```

Batched:
```
time taken: 0.22544264793395996 42
time taken: 0.20534110069274902 42
time taken: 0.20273709297180176 42
time taken: 0.20256876945495605 42
time taken: 0.20137763023376465 42
time taken: 0.20259571075439453 42
time taken: 0.2025127410888672 42
time taken: 0.20256447792053223 42
time taken: 0.20244312286376953 42
time taken: 0.20270013809204102 42
average time: 0.20502834320068358
```

