### PR TITLE
Add support of external detected landmarks.

### DIFF
--- a/examples/recognize_faces_in_pictures_alt_landmarks.py
+++ b/examples/recognize_faces_in_pictures_alt_landmarks.py
@@ -1,0 +1,77 @@
+"""
+This is an example of using alternative face landmarks detector.
+
+When should I use this example?
+This example is useful when you wish to use alternative face landmarks detector,
+e.g. you want recognize not only strcitly frontal faces.
+(default face landmarks detector give satisfactory results only with frontal faces)
+
+NOTE: This example requires face_alignment to be installed! You can install it with pip:
+
+$ pip3 install face_alignment 
+
+"""
+
+import face_recognition
+import face_alignment
+
+# Load the jpg files into numpy arrays
+biden_image = face_recognition.load_image_file("biden.jpg")
+obama_image = face_recognition.load_image_file("obama.jpg")
+unknown_image = face_recognition.load_image_file("obama2.jpg")
+
+# prepare alternative landmarks detector
+fa = face_alignment.FaceAlignment(face_alignment.LandmarksType._2D,
+                                  device='cpu',
+                                  flip_input=True)
+
+# helper method for boxes conversion
+def aligner_boxes(boxes):
+    return [(left, top, right, bottom)
+            for top, right, bottom, left in boxes]
+
+# encode end get landmarks by mean of alternative landmarks detector
+def face_encodings_and_landmarks(image):
+    # detect face locations
+    locations = face_recognition.face_locations(image, model="cnn")
+
+    # detect face landmarks
+    landmark_points = [
+        lp.astype(int).tolist()
+        for lp in fa.get_landmarks_from_image(image, aligner_boxes(locations))]
+
+    # encode faces
+    encodings = face_recognition.face_encodings(
+        image, known_face_locations=locations,
+        landmark_points=landmark_points)
+
+    # encode landmarks
+    landmarks = face_recognition.face_landmarks(
+        landmark_points=landmark_points)
+
+    return encodings, landmarks
+
+
+# Get the face encodings for each face in each image file
+# Since there could be more than one face in each image, it returns a list of encodings.
+# But since I know each image only has one face, I only care about the first encoding in each image, so I grab index 0.
+try:
+    biden_face_encoding = face_encodings_and_landmarks(biden_image)[0][0]
+    obama_face_encoding = face_encodings_and_landmarks(obama_image)[0][0]
+    unknown_face_encoding = face_encodings_and_landmarks(unknown_image)[0][0]
+except IndexError:
+    print("I wasn't able to locate any faces in at least one of the images. Check the image files. Aborting...")
+    quit()
+
+known_faces = [
+    biden_face_encoding,
+    obama_face_encoding
+]
+
+# results is an array of True/False telling if the unknown face matched anyone in the known_faces array
+results = face_recognition.compare_faces(known_faces, unknown_face_encoding)
+
+print("Is the unknown face a picture of Biden? {}".format(results[0]))
+print("Is the unknown face a picture of Obama? {}".format(results[1]))
+print("Is the unknown face a new person that we've never seen before? {}".format(
+    True not in results))

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -181,7 +181,7 @@ def face_landmarks(face_image=None, face_locations=None, model="large", landmark
     :return: A list of dicts of face feature locations (eyes, nose, etc)
     """
     if landmark_points is None:
-        landmarks = _raw_face_landmarks(face_image, face_locations, model)
+        raw_landmarks = _raw_face_landmarks(face_image, face_locations, model)
         landmarks_as_tuples = [[(p.x, p.y) for p in landmark.parts()] for landmark in raw_landmarks]
     else:
         landmarks_as_tuples = landmark_points

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -209,7 +209,7 @@ def face_landmarks(face_image=None, face_locations=None, model="large", landmark
         raise ValueError("Invalid landmarks model type. Supported models are ['small', 'large'].")
 
 
-def face_encodings(face_image=None, known_face_locations=None, num_jitters=1, model="small", landmark_points=None):
+def face_encodings(face_image, known_face_locations=None, num_jitters=1, model="small", landmark_points=None):
     """
     Given an image, return the 128-dimension face encoding for each face in the image.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 1.3.0
 commit = True
 tag = True
 


### PR DESCRIPTION
Add landmark_points parameter to face_landmarks and face_encodings methods.
It will allow to use the library with external detected landmark points.

Landmarks detection provided by default get bad result for many cases with not directly frontal face,
but by mean of using external detected landmarks (e.g. from https://github.com/1adrianb/face-alignment) possible significant improve recognition.