### PR TITLE
Blink detection fix

### DIFF
--- a/examples/blink_detection.py
+++ b/examples/blink_detection.py
@@ -57,7 +57,6 @@ def main():
                 cv2.rectangle(small_frame, left_eye[0], right_eye[-1], color, thickness)
 
                 cv2.imshow('Video', small_frame)
-                cv2.waitKey(1)
 
                 ear_left = get_ear(left_eye)
                 ear_right = get_ear(right_eye)
@@ -80,6 +79,9 @@ def main():
                     closed_count = 0
 
         process = not process
+        key = cv2.waitKey(1) & 0xFF
+        if key == ord("q"):
+            break
 
 def get_ear(eye):
 

--- a/examples/blink_detection.py
+++ b/examples/blink_detection.py
@@ -15,7 +15,6 @@ import face_recognition
 import cv2
 import time
 from scipy.spatial import distance as dist
-import keyboard as kb
 
 EYES_CLOSED_SECONDS = 5
 
@@ -74,8 +73,9 @@ def main():
                     while (asleep): #continue this loop until they wake up and acknowledge music
                         print("EYES CLOSED")
 
-                        if (kb.is_pressed('space')):
+                        if cv2.waitKey(1) == 32: #Wait for space key  
                             asleep = False
+                            print("EYES OPENED")
                     closed_count = 0
 
         process = not process


### PR DESCRIPTION
In the blink detection script, there were 2 problems. 
The first problem was quitting the script. Since the cv2.waitKey() was inside the for loop that processes the facial landmarks, we can not quit the script. It should be moved outside the for loop. I assigned "q" for exiting the script.
The second problem was the keyboard module. Using keyboard module in Linux causes the following error: "ImportError: You must be root to use this library on linux."
I replaced kb.is_pressed('space') with cv2.waitKey(1) == 32