### PR TITLE
docs: Fix simple typo, eucledian -> euclidean

### DIFF
--- a/examples/face_recognition_knn.py
+++ b/examples/face_recognition_knn.py
@@ -7,7 +7,7 @@ and make a prediction for an unknown person in a feasible computation time.
 
 Algorithm Description:
 The knn classifier is first trained on a set of labeled (known) faces and can then predict the person
-in an unknown image by finding the k most similar faces (images with closet face-features under eucledian distance)
+in an unknown image by finding the k most similar faces (images with closet face-features under euclidean distance)
 in its training set, and performing a majority vote (possibly weighted) on their label.
 
 For example, if k=3, and the three closest face images to the given image in the training set are one image of Biden

--- a/examples/facerec_ipcamera_knn.py
+++ b/examples/facerec_ipcamera_knn.py
@@ -7,7 +7,7 @@ and make a prediction for an unknown person in a feasible computation time.
 
 Algorithm Description:
 The knn classifier is first trained on a set of labeled (known) faces and can then predict the person
-in a live stream by finding the k most similar faces (images with closet face-features under eucledian distance)
+in a live stream by finding the k most similar faces (images with closet face-features under euclidean distance)
 in its training set, and performing a majority vote (possibly weighted) on their label.
 
 For example, if k=3, and the three closest face images to the given image in the training set are one image of Biden


### PR DESCRIPTION
There is a small typo in examples/face_recognition_knn.py, examples/facerec_ipcamera_knn.py.

Should read `euclidean` rather than `eucledian`.

