### PR TITLE
Add `grouping_mode' parameter to `face_landmarks'

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -165,39 +165,45 @@ def _raw_face_landmarks(face_image, face_locations=None, model="large"):
     return [pose_predictor(face_image, face_location) for face_location in face_locations]
 
 
-def face_landmarks(face_image, face_locations=None, model="large"):
+def face_landmarks(face_image, face_locations=None, model="large", grouping_mode="features"):
     """
     Given an image, returns a dict of face feature locations (eyes, nose, etc) for each face in the image
 
     :param face_image: image to search
     :param face_locations: Optionally provide a list of face locations to check.
     :param model: Optional - which model to use. "large" (default) or "small" which only returns 5 points but is faster.
+    :param grouping_mode: Optional - how to group landmarks. "features" (default) or "all" which puts all landmarks into one group.
     :return: A list of dicts of face feature locations (eyes, nose, etc)
     """
     landmarks = _raw_face_landmarks(face_image, face_locations, model)
     landmarks_as_tuples = [[(p.x, p.y) for p in landmark.parts()] for landmark in landmarks]
 
-    # For a definition of each point index, see https://cdn-images-1.medium.com/max/1600/1*AbEg31EgkbXSQehuNJBlWg.png
-    if model == 'large':
-        return [{
-            "chin": points[0:17],
-            "left_eyebrow": points[17:22],
-            "right_eyebrow": points[22:27],
-            "nose_bridge": points[27:31],
-            "nose_tip": points[31:36],
-            "left_eye": points[36:42],
-            "right_eye": points[42:48],
-            "top_lip": points[48:55] + [points[64]] + [points[63]] + [points[62]] + [points[61]] + [points[60]],
-            "bottom_lip": points[54:60] + [points[48]] + [points[60]] + [points[67]] + [points[66]] + [points[65]] + [points[64]]
-        } for points in landmarks_as_tuples]
-    elif model == 'small':
-        return [{
-            "nose_tip": [points[4]],
-            "left_eye": points[2:4],
-            "right_eye": points[0:2],
-        } for points in landmarks_as_tuples]
+    if grouping_mode == 'all':
+        return [{"all": points} for points in landmarks_as_tuples]
+    elif grouping_mode == 'features':
+        # For a definition of each point index, see https://cdn-images-1.medium.com/max/1600/1*AbEg31EgkbXSQehuNJBlWg.png
+        if model == 'large':
+            return [{
+                "chin": points[0:17],
+                "left_eyebrow": points[17:22],
+                "right_eyebrow": points[22:27],
+                "nose_bridge": points[27:31],
+                "nose_tip": points[31:36],
+                "left_eye": points[36:42],
+                "right_eye": points[42:48],
+                "top_lip": points[48:55] + [points[64]] + [points[63]] + [points[62]] + [points[61]] + [points[60]],
+                "bottom_lip": points[54:60] + [points[48]] + [points[60]] + [points[67]] + [points[66]] + [points[65]] + [points[64]]
+            } for points in landmarks_as_tuples]
+        elif model == 'small':
+            return [{
+                "nose_tip": [points[4]],
+                "left_eye": points[2:4],
+                "right_eye": points[0:2],
+            } for points in landmarks_as_tuples]
+        else:
+            raise ValueError("Invalid landmarks model type. Supported models are ['small', 'large'].")
     else:
-        raise ValueError("Invalid landmarks model type. Supported models are ['small', 'large'].")
+        raise ValueError("Invalid landmarks grouping mode. Supported modes are ['all', 'features'].")
 
 
 def face_encodings(face_image, known_face_locations=None, num_jitters=1, model="small"):

--- a/tests/test_face_recognition.py
+++ b/tests/test_face_recognition.py
@@ -120,9 +120,9 @@ class Test_face_recognition(unittest.TestCase):
         self.assertEqual(face_landmarks[0].num_parts, 68)
         self.assertEqual((example_landmark.x, example_landmark.y), (552, 399))
 
-    def test_face_landmarks(self):
+    def test_face_landmarks_grouping_features(self):
         img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
-        face_landmarks = api.face_landmarks(img)
+        face_landmarks = api.face_landmarks(img, grouping_mode="features")
 
         self.assertEqual(
             set(face_landmarks[0].keys()),
@@ -136,14 +136,50 @@ class Test_face_recognition(unittest.TestCase):
              (552, 399), (576, 372), (594, 344), (604, 314), (610, 282),
              (613, 250), (615, 219)])
 
-    def test_face_landmarks_small_model(self):
+    def test_face_landmarks_grouping_all(self):
         img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
-        face_landmarks = api.face_landmarks(img, model="small")
+        face_landmarks = api.face_landmarks(img, grouping_mode="all")
+
+        self.assertEqual(
+            set(face_landmarks[0].keys()),
+            set(['all']))
+        self.assertEqual(len(face_landmarks[0]['all']), 68)
+        self.assertEqual(
+            face_landmarks[0]['all'][:5],
+            [(369, 220), (372, 254), (378, 289), (384, 322), (395, 353)])
+
+    def test_face_landmarks(self):
+        img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
+        face_landmarks_default = api.face_landmarks(img)
+        face_landmarks_features = api.face_landmarks(img, grouping_mode="features")
+
+        self.assertEqual(face_landmarks_default, face_landmarks_features)
+
+    def test_face_landmarks_small_model_grouping_features(self):
+        img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
+        face_landmarks = api.face_landmarks(img, model="small", grouping_mode="features")
 
         self.assertEqual(
             set(face_landmarks[0].keys()),
             set(['nose_tip', 'left_eye', 'right_eye']))
         self.assertEqual(face_landmarks[0]['nose_tip'], [(496, 295)])
+
+    def test_face_landmarks_small_model_grouping_all(self):
+        img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
+        face_landmarks = api.face_landmarks(img, model="small", grouping_mode="all")
+
+        self.assertEqual(
+            set(face_landmarks[0].keys()),
+            set(['all']))
+        self.assertEqual(len(face_landmarks[0]['all']), 5)
+        self.assertEqual(face_landmarks[0]['all'][4], (496, 295))
+
+    def test_face_landmarks_small_model(self):
+        img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))
+        face_landmarks_default = api.face_landmarks(img, model="small")
+        face_landmarks_features = api.face_landmarks(img, model="small", grouping_mode="features")
+
+        self.assertEqual(face_landmarks_default, face_landmarks_features)
 
     def test_face_encodings(self):
         img = api.load_image_file(os.path.join(os.path.dirname(__file__), 'test_images', 'obama.jpg'))


### PR DESCRIPTION
Sometimes it would be convenient to get a list of face landmarks without any additional grouping. For example, if we need to create a data frame with landmark coordinates, we will unlikely need duplicate columns caused by some landmarks included in different facial features at the same time.

I would propose to add an extra parameter, `grouping_mode`, to `face_landmarks` which specifies how to group produced landmarks.

Following modes are currently supported:

  * "features" (default): group by face features (eyes, nose, etc.);

  * "all": put all landmarks in one group.