### PR TITLE
rotate image according to exif #917

### DIFF
--- a/examples/face_recognition_knn.py
+++ b/examples/face_recognition_knn.py
@@ -36,7 +36,7 @@ from sklearn import neighbors
 import os
 import os.path
 import pickle
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageOps
 import face_recognition
 from face_recognition.face_recognition_cli import image_files_in_folder
 
@@ -159,6 +159,7 @@ def show_prediction_labels_on_image(img_path, predictions):
     :return:
     """
     pil_image = Image.open(img_path).convert("RGB")
+    pil_image = ImageOps.exif_transpose(pil_image)
     draw = ImageDraw.Draw(pil_image)
 
     for name, (top, right, bottom, left) in predictions:

--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -3,7 +3,7 @@
 import PIL.Image
 import dlib
 import numpy as np
-from PIL import ImageFile
+from PIL import ImageFile, ImageOps
 
 try:
     import face_recognition_models
@@ -84,6 +84,7 @@ def load_image_file(file, mode='RGB'):
     :return: image contents as numpy array
     """
     im = PIL.Image.open(file)
+    im = ImageOps.exif_transpose(im)
     if mode:
         im = im.convert(mode)
     return np.array(im)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ face_recognition_models
 Click>=6.0
 dlib>=19.3.0
 numpy
-Pillow
+Pillow>=6.0.0
 scipy>=0.17.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'Click>=6.0',
     'dlib>=19.7',
     'numpy',
-    'Pillow'
+    'Pillow>=6.0.0'
 ]
 
 test_requirements = [


### PR DESCRIPTION
After recognizing faces on an image sometimes the images rotate sideways because of EXIF. It can be easily solved by rotating the image according to EXIF after loading. 
PIL already has a method `PIL.ImageOps.exif_transpose(image)` to do this. Which will apply EXIF transform if required.

**What I did:**
Rotate the image according to EXIF after loading it before doing anything. 