### PR TITLE
There is a typo in face_recognition/example/facerec_ipcamera_knn.py

### DIFF
--- a/examples/facerec_ipcamera_knn.py
+++ b/examples/facerec_ipcamera_knn.py
@@ -209,6 +209,6 @@ if __name__ == "__main__":
             frame = show_prediction_labels_on_image(frame, predictions)
             cv2.imshow('camera', frame)
             if ord('q') == cv2.waitKey(10):
-                cap1.release()
+                cap.release()
                 cv2.destroyAllWindows()
                 exit(0)


### PR DESCRIPTION
The third last line (line no. 212) is written as cap1.release(). It should be cap.release instead.
cap1.release() > cap.release()