### PR TITLE
Update api.py

### DIFF
--- a/face_recognition/api.py
+++ b/face_recognition/api.py
@@ -4,13 +4,14 @@ import PIL.Image
 import dlib
 import numpy as np
 from PIL import ImageFile
+import sys
 
 try:
     import face_recognition_models
 except Exception:
     print("Please install `face_recognition_models` with this command before using `face_recognition`:\n")
     print("pip install git+https://github.com/ageitgey/face_recognition_models")
-    quit()
+    sys.exit()
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 


### PR DESCRIPTION
Use of exit or quit method will raise error if interpreter is started with -S flag.
The exit and quit functions are actually site.Quitter objects and are loaded, at interpreter start up, from site.py. However, if the interpreter is started with the -S flag, or a custom site.py is used then exit and quit may not be present. It is recommended to use sys.exit() which is built into the interpreter and is guaranteed to be present.