### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ your folder of known people.
 
 #### `face_detection` command line tool
 
-The `face_detection` command lets you find the location (pixel coordinatates) 
+The `face_detection` command lets you find the location (pixel coordinates) 
 of any faces in an image.
 
 Just run the command `face_detection`, passing in a folder of images 
@@ -270,7 +270,7 @@ You can also opt-in to a somewhat more accurate deep-learning-based face detecti
 
 Note: GPU acceleration (via NVidia's CUDA library) is required for good
 performance with this model. You'll also want to enable CUDA support
-when compliling `dlib`.
+when compiling `dlib`.
 
 ```python
 import face_recognition

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ detection model.
 | Note: GPU acceleration (via nvidia's CUDA library) is required for
   good
 | performance with this model. You'll also want to enable CUDA support
-| when compliling ``dlib``.
+| when compiling ``dlib``.
 
 .. code:: python
 

--- a/examples/face_distance.py
+++ b/examples/face_distance.py
@@ -23,7 +23,7 @@ known_encodings = [
     biden_face_encoding
 ]
 
-# Load a test image and get encondings for it
+# Load a test image and get encodings for it
 image_to_test = face_recognition.load_image_file("obama2.jpg")
 image_to_test_encoding = face_recognition.face_encodings(image_to_test)[0]
 

--- a/examples/face_recognition_knn.py
+++ b/examples/face_recognition_knn.py
@@ -139,7 +139,7 @@ def predict(X_img_path, knn_clf=None, model_path=None, distance_threshold=0.6):
     if len(X_face_locations) == 0:
         return []
 
-    # Find encodings for faces in the test iamge
+    # Find encodings for faces in the test image
     faces_encodings = face_recognition.face_encodings(X_img, known_face_locations=X_face_locations)
 
     # Use the KNN model to find the best matches for the test face

--- a/examples/facerec_from_webcam.py
+++ b/examples/facerec_from_webcam.py
@@ -37,7 +37,7 @@ while True:
     # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
     rgb_frame = frame[:, :, ::-1]
 
-    # Find all the faces and face enqcodings in the frame of video
+    # Find all the faces and face encodings in the frame of video
     face_locations = face_recognition.face_locations(rgb_frame)
     face_encodings = face_recognition.face_encodings(rgb_frame, face_locations)
 

--- a/examples/facerec_ipcamera_knn.py
+++ b/examples/facerec_ipcamera_knn.py
@@ -156,7 +156,7 @@ def show_prediction_labels_on_image(frame, predictions):
 
     :param frame: frame to show the predictions on
     :param predictions: results of the predict function
-    :return opencv suited image to be fitting with cv2.imshow fucntion:
+    :return opencv suited image to be fitting with cv2.imshow function:
     """
     pil_image = Image.fromarray(frame)
     draw = ImageDraw.Draw(pil_image)


### PR DESCRIPTION
There are small typos in:
- README.md
- README.rst
- examples/face_distance.py
- examples/face_recognition_knn.py
- examples/facerec_from_webcam.py
- examples/facerec_ipcamera_knn.py

Fixes:
- Should read `compiling` rather than `compliling`.
- Should read `image` rather than `iamge`.
- Should read `function` rather than `fucntion`.
- Should read `encodings` rather than `enqcodings`.
- Should read `encodings` rather than `encondings`.
- Should read `coordinates` rather than `coordinatates`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md