### PR TITLE
fix(opencv): convert color space to RGB for compatibility with face_recognition

### DIFF
--- a/examples/blink_detection.py
+++ b/examples/blink_detection.py
@@ -35,7 +35,8 @@ def main():
 
         # get it into the correct format
         small_frame = cv2.resize(frame, (0, 0), fx=0.25, fy=0.25)
-        rgb_small_frame = small_frame[:, :, ::-1]
+        # rgb_small_frame = small_frame[:, :, ::-1]
+        rgb_small_frame = cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)
 
 
 

--- a/examples/facerec_from_video_file.py
+++ b/examples/facerec_from_video_file.py
@@ -43,7 +43,8 @@ while True:
         break
 
     # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
-    rgb_frame = frame[:, :, ::-1]
+    # rgb_frame = frame[:, :, ::-1]
+    rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
     # Find all the faces and face encodings in the current frame of video
     face_locations = face_recognition.face_locations(rgb_frame)

--- a/examples/facerec_from_webcam.py
+++ b/examples/facerec_from_webcam.py
@@ -35,7 +35,8 @@ while True:
     ret, frame = video_capture.read()
 
     # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
-    rgb_frame = frame[:, :, ::-1]
+    # rgb_frame = frame[:, :, ::-1]
+    rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
     # Find all the faces and face enqcodings in the frame of video
     face_locations = face_recognition.face_locations(rgb_frame)

--- a/examples/facerec_from_webcam_faster.py
+++ b/examples/facerec_from_webcam_faster.py
@@ -48,7 +48,9 @@ while True:
         small_frame = cv2.resize(frame, (0, 0), fx=0.25, fy=0.25)
 
         # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
-        rgb_small_frame = small_frame[:, :, ::-1]
+        # rgb_small_frame = small_frame[:, :, ::-1]
+        # fix running error : TypeError: compute_face_descriptor(): incompatible function arguments. The following argument types are supported:
+        rgb_small_frame = cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)
         
         # Find all the faces and face encodings in the current frame of video
         face_locations = face_recognition.face_locations(rgb_small_frame)

--- a/examples/facerec_from_webcam_multiprocessing.py
+++ b/examples/facerec_from_webcam_multiprocessing.py
@@ -78,7 +78,8 @@ def process(worker_id, read_frame_list, write_frame_list, Global, worker_num):
         Global.read_num = next_id(Global.read_num, worker_num)
 
         # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
-        rgb_frame = frame_process[:, :, ::-1]
+        # rgb_frame = frame_process[:, :, ::-1]
+        rgb_frame = cv2.cvtColor(frame_process, cv2.COLOR_BGR2RGB)
 
         # Find all the faces and face encodings in the frame of video, cost most time
         face_locations = face_recognition.face_locations(rgb_frame)


### PR DESCRIPTION
The `rgb_small_frame` variable was previously assigned using slicing to convert the color space from BGR to RGB. However, this caused a `TypeError` when passing the `rgb_small_frame` variable to the `compute_face_descriptor()` function from the `face_recognition` library. 

This commit fixes the issue by using the `cv2.cvtColor()` function from OpenCV to convert the color space of the `small_frame` input to RGB directly. 

This commit resolves running error : TypeError: compute_face_descriptor(): incompatible function arguments. The following argument types are supported