### PR TITLE
Update facerec_from_webcam_faster.py

### DIFF
--- a/examples/facerec_from_webcam_faster.py
+++ b/examples/facerec_from_webcam_faster.py
@@ -48,7 +48,7 @@ while True:
         small_frame = cv2.resize(frame, (0, 0), fx=0.25, fy=0.25)
 
         # Convert the image from BGR color (which OpenCV uses) to RGB color (which face_recognition uses)
-        rgb_small_frame = small_frame[:, :, ::-1]
+        rgb_small_frame = cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)
         
         # Find all the faces and face encodings in the current frame of video
         face_locations = face_recognition.face_locations(rgb_small_frame)


### PR DESCRIPTION
Previously, the code used array slicing (`[:, :, ::-1]`) to convert BGR to RGB,   which occasionally caused `TypeError` in `dlib`'s `compute_face_descriptor()`.   I replaces the slicing method with `cv2.cvtColor(small_frame, cv2.COLOR_BGR2RGB)`  The fix addresses issues where face recognition failed due to incorrect color channel handling.