### PR TITLE
Fix dead LFW benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the world's simplest face recognition library.
 
 Built using [dlib](http://dlib.net/)'s state-of-the-art face recognition
 built with deep learning. The model has an accuracy of 99.38% on the
-[Labeled Faces in the Wild](http://vis-www.cs.umass.edu/lfw/) benchmark.
+[Labeled Faces in the Wild](https://people.cs.umass.edu/~elm/papers/lfw.pdf) benchmark.
 
 This also provides a simple `face_recognition` command line tool that lets
 you do face recognition on a folder of images from the command line!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the world's simplest face recognition library.
 
 Built using [dlib](http://dlib.net/)'s state-of-the-art face recognition
 built with deep learning. The model has an accuracy of 99.38% on the
-[Labeled Faces in the Wild](https://people.cs.umass.edu/~elm/papers/lfw.pdf) benchmark.
+Labeled Faces in the Wild benchmark (see the [LFW paper (PDF)](https://people.cs.umass.edu/~elm/papers/lfw.pdf)).
 
 This also provides a simple `face_recognition` command line tool that lets
 you do face recognition on a folder of images from the command line!


### PR DESCRIPTION
## Summary

- Replaces the dead Labeled Faces in the Wild benchmark link with the UMass-hosted LFW paper PDF suggested in #1670.

Fixes #1670.

## Validation

- Confirmed `http://vis-www.cs.umass.edu/lfw/` no longer resolves.
- Confirmed `https://people.cs.umass.edu/~elm/papers/lfw.pdf` returns HTTP 200.